### PR TITLE
Update onAdd and toggleCartItemQuantity

### DIFF
--- a/context/StateContext.js
+++ b/context/StateContext.js
@@ -13,29 +13,35 @@ export const StateContext = ({ children }) => {
   let foundProduct;
   let index;
 
-  const onAdd = (product, quantity) => {
-    const checkProductInCart = cartItems.find((item) => item._id === product._id);
-    
-    setTotalPrice((prevTotalPrice) => prevTotalPrice + product.price * quantity);
-    setTotalQuantities((prevTotalQuantities) => prevTotalQuantities + quantity);
-    
-    if(checkProductInCart) {
-      const updatedCartItems = cartItems.map((cartProduct) => {
-        if(cartProduct._id === product._id) return {
-          ...cartProduct,
-          quantity: cartProduct.quantity + quantity
+  const onAdd = (product, quantity) =>
+    {
+        // see if product is already in the cart
+        const productInCart = cartItems.find((item) => item._id === product._id);
+        // this needs to happen regardless if item is already in cart
+        setTotalPrice(prevTotalPrice => prevTotalPrice + product.price * quantity);
+        setTotalQuantities(prevTotalQuantities => prevTotalQuantities + quantity);
+        // if product is already in cart -> add new quantity to previous quantity
+        if (productInCart)
+        {
+            const updatedCartItems = cartItems.map((item) =>
+            {
+                // find the matching product and adjust the number in the cart
+                if (item._id === product._id)
+                {
+                    return { ...item, quantity: item.quantity + quantity };
+                }
+            });
+            setCartItems(updatedCartItems);
         }
-      })
-
-      setCartItems(updatedCartItems);
-    } else {
-      product.quantity = quantity;
-      
-      setCartItems([...cartItems, { ...product }]);
+        else
+        {
+            product.quantity = quantity;
+            setCartItems([...cartItems, { ...product }]);
+        }
+        toast.success(`${qty} ${product.name} added to the cart.`);
+        // so each product defaults to 1 when navigating to a new product
+        setQty(1);
     }
-
-    toast.success(`${qty} ${product.name} added to the cart.`);
-  } 
 
   const onRemove = (product) => {
     foundProduct = cartItems.find((item) => item._id === product._id);
@@ -46,23 +52,31 @@ export const StateContext = ({ children }) => {
     setCartItems(newCartItems);
   }
 
-  const toggleCartItemQuanitity = (id, value) => {
-    foundProduct = cartItems.find((item) => item._id === id)
-    index = cartItems.findIndex((product) => product._id === id);
-    const newCartItems = cartItems.filter((item) => item._id !== id)
+  const toggleCartItemQuantity = (id, value) =>
+  {
+      foundProduct = cartItems.find((item) => item._id === id);
+      index = cartItems.findIndex((product) => product._id === id);
 
-    if(value === 'inc') {
-      setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity + 1 } ]);
-      setTotalPrice((prevTotalPrice) => prevTotalPrice + foundProduct.price)
-      setTotalQuantities(prevTotalQuantities => prevTotalQuantities + 1)
-    } else if(value === 'dec') {
-      if (foundProduct.quantity > 1) {
-        setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity - 1 } ]);
-        setTotalPrice((prevTotalPrice) => prevTotalPrice - foundProduct.price)
-        setTotalQuantities(prevTotalQuantities => prevTotalQuantities - 1)
+      if (value === 'inc')
+      {
+          foundProduct.quantity += 1;
+          setTotalPrice(prevTotalPrice => prevTotalPrice + foundProduct.price);
+          setTotalQuantities(prevTotalQuantities => prevTotalQuantities + 1);
+      } else if (value === 'dec')
+      {
+          if (foundProduct.quantity > 1)
+          {
+              foundProduct.quantity -= 1;
+              setTotalPrice(prevTotalPrice => prevTotalPrice - foundProduct.price);
+              setTotalQuantities(prevTotalQuantities => prevTotalQuantities - 1);
+          }
       }
-    }
-  }
+      let newCartItems = cartItems.map((item, i) =>
+      {
+          return i === index ? foundProduct : item;
+      });
+      setCartItems(newCartItems);
+  };
 
   const incQty = () => {
     setQty((prevQty) => prevQty + 1);


### PR DESCRIPTION
Reset qty to 1 at the end of onAdd. This prevents the previous value of qty from carrying over between different product pages.
Also used Array.map to update quantity changes in the cart and maintain ordering.