### PR TITLE
updating toggle quantity issue on addition and decrement of cart item on cart page That it  goes t bottom

### DIFF
--- a/context/StateContext.js
+++ b/context/StateContext.js
@@ -48,18 +48,27 @@ export const StateContext = ({ children }) => {
 
   const toggleCartItemQuanitity = (id, value) => {
     foundProduct = cartItems.find((item) => item._id === id)
-    index = cartItems.findIndex((product) => product._id === id);
-    const newCartItems = cartItems.filter((item) => item._id !== id)
-
+    const newCartItems = cartItems
     if(value === 'inc') {
-      setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity + 1 } ]);
       setTotalPrice((prevTotalPrice) => prevTotalPrice + foundProduct.price)
       setTotalQuantities(prevTotalQuantities => prevTotalQuantities + 1)
+      /* I am using a  for loop rather than editing the single object by using it's id which is returning me a array with the modified object quantity*/
+      /* The issue with the las code was that we are appending the founded object to a filtered object which is always comes at last
+      for(const obj of newCartItems){
+        if (obj.id == foundProduct.id) {
+          obj.quantity = obj.quantity + 1;
+        }
+      }
+      setCartItems(newCartItems);
     } else if(value === 'dec') {
       if (foundProduct.quantity > 1) {
-        setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity - 1 } ]);
-        setTotalPrice((prevTotalPrice) => prevTotalPrice - foundProduct.price)
-        setTotalQuantities(prevTotalQuantities => prevTotalQuantities - 1)
+      // I am using a  for loop rather than editing the single object by using it's id which is returning me a array with the modified object quantity
+      for(const obj of newCartItems){
+        if (obj.id == foundProduct.id) {
+          obj.quantity = obj.quantity - 1;
+        }
+      }
+      setCartItems(newCartItems);
       }
     }
   }


### PR DESCRIPTION
I am using a  for loop rather than editing the single object by using its id which is returninan me a Array with the modified object quantity
ISSUE: the last code has been using the filter to separate the object and apending the toggled object at the end
The issue with the last code was that we are appending the founded object to a filtered object which always comes at last.
Now it's working finely the cart item remains at the same place rather than going to to the bottom on inc  or dec