### PR TITLE
stopped cart position changes

### DIFF
--- a/context/StateContext.js
+++ b/context/StateContext.js
@@ -52,17 +52,17 @@ export const StateContext = ({ children }) => {
     const newCartItems = cartItems.filter((item) => item._id !== id)
 
     if(value === 'inc') {
-      setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity + 1 } ]);
+      setCartItems([...cartItems.slice(0, index), { ...foundProduct, quantity: foundProduct.quantity + 1 }, ...cartItems.slice(index + 1) ])
       setTotalPrice((prevTotalPrice) => prevTotalPrice + foundProduct.price)
       setTotalQuantities(prevTotalQuantities => prevTotalQuantities + 1)
     } else if(value === 'dec') {
-      if (foundProduct.quantity > 1) {
-        setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity - 1 } ]);
-        setTotalPrice((prevTotalPrice) => prevTotalPrice - foundProduct.price)
-        setTotalQuantities(prevTotalQuantities => prevTotalQuantities - 1)
+        if (foundProduct.quantity > 1) {
+          setCartItems([...cartItems.slice(0, index), { ...foundProduct, quantity: foundProduct.quantity - 1 }, ...cartItems.slice(index + 1) ])
+          setTotalPrice((prevTotalPrice) => prevTotalPrice - foundProduct.price)
+          setTotalQuantities(prevTotalQuantities => prevTotalQuantities - 1)
+        }
       }
     }
-  }
 
   const incQty = () => {
     setQty((prevQty) => prevQty + 1);


### PR DESCRIPTION
After trying multiple things and learning that sorts are not likely successful in React, I found a comment from Jamal Dabas which seems to have corrected the issue. I will try to cause each products page to default to 1 item selected after changing it on another page.