### PR TITLE
Fix cart items reordering using Array.map transform

### DIFF
--- a/components/Cart.jsx
+++ b/components/Cart.jsx
@@ -8,9 +8,18 @@ import { useStateContext } from '../context/StateContext';
 import { urlFor } from '../lib/client';
 import getStripe from '../lib/getStripe';
 
+
+// fix typo error: replace 'toggleCartItemQuanitity' to 'toggleCartItemQuantity'
 const Cart = () => {
   const cartRef = useRef();
-  const { totalPrice, totalQuantities, cartItems, setShowCart, toggleCartItemQuanitity, onRemove } = useStateContext();
+  const {
+    totalPrice,
+    totalQuantities,
+    cartItems,
+    setShowCart,
+    toggleCartItemQuantity,
+    onRemove,
+  } = useStateContext();
 
   const handleCheckout = async () => {
     const stripe = await getStripe();
@@ -33,26 +42,27 @@ const Cart = () => {
   }
 
   return (
-    <div className="cart-wrapper" ref={cartRef}>
-      <div className="cart-container">
+    <div className='cart-wrapper' ref={cartRef}>
+      <div className='cart-container'>
         <button
-        type="button"
-        className="cart-heading"
-        onClick={() => setShowCart(false)}>
+          type='button'
+          className='cart-heading'
+          onClick={() => setShowCart(false)}
+        >
           <AiOutlineLeft />
-          <span className="heading">Your Cart</span>
-          <span className="cart-num-items">({totalQuantities} items)</span>
+          <span className='heading'>Your Cart</span>
+          <span className='cart-num-items'>({totalQuantities} items)</span>
         </button>
 
         {cartItems.length < 1 && (
-          <div className="empty-cart">
+          <div className='empty-cart'>
             <AiOutlineShopping size={150} />
             <h3>Your shopping bag is empty</h3>
-            <Link href="/">
+            <Link href='/'>
               <button
-                type="button"
+                type='button'
                 onClick={() => setShowCart(false)}
-                className="btn"
+                className='btn'
               >
                 Continue Shopping
               </button>
@@ -60,45 +70,63 @@ const Cart = () => {
           </div>
         )}
 
-        <div className="product-container">
-          {cartItems.length >= 1 && cartItems.map((item) => (
-            <div className="product" key={item._id}>
-              <img src={urlFor(item?.image[0])} className="cart-product-image" />
-              <div className="item-desc">
-                <div className="flex top">
-                  <h5>{item.name}</h5>
-                  <h4>${item.price}</h4>
-                </div>
-                <div className="flex bottom">
-                  <div>
-                  <p className="quantity-desc">
-                    <span className="minus" onClick={() => toggleCartItemQuanitity(item._id, 'dec') }>
-                    <AiOutlineMinus />
-                    </span>
-                    <span className="num" onClick="">{item.quantity}</span>
-                    <span className="plus" onClick={() => toggleCartItemQuanitity(item._id, 'inc') }><AiOutlinePlus /></span>
-                  </p>
+        <div className='product-container'>
+          {cartItems.length >= 1 &&
+            cartItems.map((item) => (
+              <div className='product' key={item._id}>
+                <img
+                  src={urlFor(item?.image[0])}
+                  className='cart-product-image'
+                />
+                <div className='item-desc'>
+                  <div className='flex top'>
+                    <h5>{item.name}</h5>
+                    <h4>${item.price}</h4>
                   </div>
-                  <button
-                    type="button"
-                    className="remove-item"
-                    onClick={() => onRemove(item)}
-                  >
-                    <TiDeleteOutline />
-                  </button>
+                  <div className='flex bottom'>
+                    <div>
+                      <p className='quantity-desc'>
+                        <span
+                          className='minus'
+                          onClick={() =>
+                            toggleCartItemQuantity(item._id, 'dec')
+                          }
+                        >
+                          <AiOutlineMinus />
+                        </span>
+                        <span className='num' onClick=''>
+                          {item.quantity}
+                        </span>
+                        <span
+                          className='plus'
+                          onClick={() =>
+                            toggleCartItemQuantity(item._id, 'inc')
+                          }
+                        >
+                          <AiOutlinePlus />
+                        </span>
+                      </p>
+                    </div>
+                    <button
+                      type='button'
+                      className='remove-item'
+                      onClick={() => onRemove(item)}
+                    >
+                      <TiDeleteOutline />
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            ))}
         </div>
         {cartItems.length >= 1 && (
-          <div className="cart-bottom">
-            <div className="total">
+          <div className='cart-bottom'>
+            <div className='total'>
               <h3>Subtotal:</h3>
               <h3>${totalPrice}</h3>
             </div>
-            <div className="btn-container">
-              <button type="button" className="btn" onClick={handleCheckout}>
+            <div className='btn-container'>
+              <button type='button' className='btn' onClick={handleCheckout}>
                 Pay with Stripe
               </button>
             </div>
@@ -106,7 +134,7 @@ const Cart = () => {
         )}
       </div>
     </div>
-  )
+  );
 }
 
 export default Cart

--- a/context/StateContext.js
+++ b/context/StateContext.js
@@ -46,23 +46,38 @@ export const StateContext = ({ children }) => {
     setCartItems(newCartItems);
   }
 
-  const toggleCartItemQuanitity = (id, value) => {
-    foundProduct = cartItems.find((item) => item._id === id)
-    index = cartItems.findIndex((product) => product._id === id);
-    const newCartItems = cartItems.filter((item) => item._id !== id)
+  const toggleCartItemQuantity = (id, value) => {
+    foundProduct = cartItems.find((item) => item._id === id);
+    productIndex = cartItems.findIndex((item) => item._id === id);
 
-    if(value === 'inc') {
-      setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity + 1 } ]);
-      setTotalPrice((prevTotalPrice) => prevTotalPrice + foundProduct.price)
-      setTotalQuantities(prevTotalQuantities => prevTotalQuantities + 1)
-    } else if(value === 'dec') {
+    // update cart product using Array.map transformation instead of filtering and appending
+    if (value === 'inc') {
+      setCartItems(
+        cartItems.map((item) => {
+          if (item._id === id) {
+            return { ...item, quantity: item.quantity + 1 };
+          }
+          return item;
+        }),
+      );
+      setTotalPrice((prevTotalPrice) => prevTotalPrice + foundProduct.price);
+      setTotalQuantities((prevTotalQuanties) => prevTotalQuanties + 1);
+    } else if (value === 'dec') {
       if (foundProduct.quantity > 1) {
-        setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity - 1 } ]);
-        setTotalPrice((prevTotalPrice) => prevTotalPrice - foundProduct.price)
-        setTotalQuantities(prevTotalQuantities => prevTotalQuantities - 1)
+        setCartItems(
+          cartItems.map((item, i) => {
+            if (item._id === id) {
+              return { ...item, quantity: item.quantity - 1 };
+            }
+            return item;
+          }),
+        );
+        setTotalPrice((prevTotalPrice) => prevTotalPrice - foundProduct.price);
+        setTotalQuantities((prevTotalQuantities) => prevTotalQuantities - 1);
       }
     }
-  }
+  };
+
 
   const incQty = () => {
     setQty((prevQty) => prevQty + 1);
@@ -88,7 +103,7 @@ export const StateContext = ({ children }) => {
         incQty,
         decQty,
         onAdd,
-        toggleCartItemQuanitity,
+        toggleCartItemQuantity,
         onRemove,
         setCartItems,
         setTotalPrice,


### PR DESCRIPTION
#toggleCartItemQuantity function in stateContext
Reordering of cart products is due to filtering the cart items to remove the found product followed by appending the mutated found product to the end of the cart. Instead, simply mapping over the items and returning an updated item for the specific item we are searching would preserve the order.