### PR TITLE
Fix for cart reordering while adding quantity.

### DIFF
--- a/context/StateContext.js
+++ b/context/StateContext.js
@@ -46,18 +46,22 @@ export const StateContext = ({ children }) => {
     setCartItems(newCartItems);
   }
 
-  const toggleCartItemQuanitity = (id, value) => {
+  const toggleCartItemQuantity = (id, value) => {
     foundProduct = cartItems.find((item) => item._id === id)
     index = cartItems.findIndex((product) => product._id === id);
-    const newCartItems = cartItems.filter((item) => item._id !== id)
+    const newCartItems = [...cartItems]; // for mutating the array in place
 
     if(value === 'inc') {
-      setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity + 1 } ]);
+      foundProduct.quantity += 1;
+      newCartItems[index] = foundProduct;  // prevents reordering
+      setCartItems(newCartItems)
       setTotalPrice((prevTotalPrice) => prevTotalPrice + foundProduct.price)
       setTotalQuantities(prevTotalQuantities => prevTotalQuantities + 1)
     } else if(value === 'dec') {
       if (foundProduct.quantity > 1) {
-        setCartItems([...newCartItems, { ...foundProduct, quantity: foundProduct.quantity - 1 } ]);
+        foundProduct.quantity -= 1;
+        newCartItems[index] = foundProduct
+        setCartItems(newCartItems)
         setTotalPrice((prevTotalPrice) => prevTotalPrice - foundProduct.price)
         setTotalQuantities(prevTotalQuantities => prevTotalQuantities - 1)
       }


### PR DESCRIPTION
Create a copy of the cartItems:
`    const newCartItems = [...cartItems]; // for mutating the array in place`

now we increase quantity, in the foundProduct and simply add it in the new array using index to prevent reordering.

```
    if(value === 'inc') {
      foundProduct.quantity += 1;
      newCartItems[index] = foundProduct;  // prevents reordering
      setCartItems(newCartItems)
```
